### PR TITLE
allow self hosted gitlab server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![NPM version](https://img.shields.io/npm/v/adonis-ally-gitlab.svg)](https://www.npmjs.com/package/adonis-ally-gitlab)
 
-A [Gitlab](https://gitlab.com/) driver for [AdonisJS Ally](https://docs.adonisjs.com/guides/auth/social)
+A [Gitlab](https://gitlab.com/) driver for [AdonisJS Ally](https://docs.adonisjs.com/guides/auth/social).
+You can authenticate with your self hosted gitlab or with https://gitlab.com/
 
 ## Getting started
 
@@ -29,6 +30,7 @@ node ace configure adonis-ally-gitlab
 ### 3. Validate environment variables
 
 ```ts
+GITLAB_URL: Env.schema.string(),
 GITLAB_CLIENT_ID: Env.schema.string(),
 GITLAB_CLIENT_SECRET: Env.schema.string(),
 ```
@@ -40,6 +42,7 @@ const allyConfig: AllyConfig = {
   // ... other drivers
   gitlab: {
     driver: 'gitlab',
+    gitlabUrl: 'https://gitlab.example.com/'
     clientId: Env.get('GITLAB_CLIENT_ID'),
     clientSecret: Env.get('GITLAB_CLIENT_SECRET'),
     callbackUrl: 'http://localhost:3333/gitlab/callback',
@@ -47,9 +50,14 @@ const allyConfig: AllyConfig = {
 }
 ```
 
+If you don't supply gitlabUrl, https.//www.gitlab.com/ will be used.
+
+When using self hosted gitlab,
+get the clientId and clientSecret from /admin/applications/ on your gitlab instance.
+
 ## Scopes
 
-You can pass an array of scopes in your configuration, for example `['user', 'profile', 'api']`. You have a full list of scopes in the [Gitlab Oauth documentation](https://docs.gitlab.com/ee/integration/oauth_provider.html#authorized-applications)
+You can pass an array of scopes in your configuration, for example `['read_user', 'profile', 'api']`. You have a full list of scopes in the [Gitlab Oauth documentation](https://docs.gitlab.com/ee/integration/oauth_provider.html#authorized-applications)
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const allyConfig: AllyConfig = {
 }
 ```
 
-If you don't supply gitlabUrl, https.//www.gitlab.com/ will be used.
+If you don't supply gitlabUrl, https://www.gitlab.com/ will be used.
 
 When using self hosted gitlab,
 get the clientId and clientSecret from /admin/applications/ on your gitlab instance.

--- a/src/Gitlab/index.ts
+++ b/src/Gitlab/index.ts
@@ -27,6 +27,7 @@ export type GitlabScopes =
 
 export type GitlabDriverConfig = {
   driver: 'gitlab'
+  gitlabUrl?: string
   clientId: string
   clientSecret: string
   callbackUrl: string
@@ -53,7 +54,11 @@ export class GitlabDriver extends Oauth2Driver<GitlabAccessToken, GitlabScopes> 
 
   constructor(ctx: HttpContextContract, public config: GitlabDriverConfig) {
     super(ctx, config)
-
+    if (config.gitlabUrl) {
+      this.authorizeUrl = config.gitlabUrl + 'oauth/authorize'
+      this.accessTokenUrl = config.gitlabUrl + 'oauth/token'
+      this.userInfoUrl = config.gitlabUrl + 'api/v4/user'
+    }
     this.loadState()
   }
 


### PR DESCRIPTION
Hello rubenmoya,

I use your package to authenticate with my self hosted gitlab.
To get this to work I had to do only a little modification - maybe you want to merge it?

This pull request adds one line to the configuration:

`gitlabUrl: 'https://gitlab.example.com/', `

If you don't supply gitlabUrl, https.//www.gitlab.com/ will be used.
So existing installs should not be affected.

This is a minimal pull request, I did not bump the version number in package.json